### PR TITLE
refactor(webpack) remove relative paths by adding webpack aliases

### DIFF
--- a/src/dialogue/components/content-router/__test__/content-router.spec.js
+++ b/src/dialogue/components/content-router/__test__/content-router.spec.js
@@ -4,7 +4,7 @@ import Cycle                from '@cycle/core'
 import {div, makeDOMDriver} from '@cycle/dom'
 import {makeHistoryDriver}  from '@cycle/history';
 import contentRouter        from '../content-router-index'
-import createRenderTarget   from '../../../../__test__/helper/createRenderTarget'
+import createRenderTarget   from '__test_helper__/createRenderTarget'
 
 const url = {
   home: {path: `/`},

--- a/src/dialogue/components/content-router/content-router-index.js
+++ b/src/dialogue/components/content-router/content-router-index.js
@@ -1,10 +1,10 @@
 import switchPath from 'switch-path';
 import Rx         from 'rx';
 import isolate    from '@cycle/isolate';
-import Home       from '../../pages/home/home-index';
-import Page1      from '../../pages/page1/page1-index';
-import Page2      from '../../pages/page2/page2-index';
-import Page404    from '../../pages/page404/page404-index';
+import Home       from 'pages/home/home-index';
+import Page1      from 'pages/page1/page1-index';
+import Page2      from 'pages/page2/page2-index';
+import Page404    from 'pages/page404/page404-index';
 
 function ContentRouter(sources) {
   const sinks$ = sources.History.map(({pathname}) => {

--- a/src/dialogue/components/navbar/navbar-index.js
+++ b/src/dialogue/components/navbar/navbar-index.js
@@ -1,4 +1,4 @@
-import {extractValue} from '../../utils/utils'
+import {extractValue} from 'utils/utils'
 import intent         from './navbar-intent'
 import model          from './navbar-model'
 import view           from './navbar-view'

--- a/src/dialogue/components/navbar/navbar-intent.js
+++ b/src/dialogue/components/navbar/navbar-intent.js
@@ -1,4 +1,4 @@
-import {getUrl, extractValue, events}   from '../../utils/utils'
+import {getUrl, extractValue, events}   from 'utils/utils'
 
 // Our navbar need some intent, our intent looks out for clicks on elements with the class of .link
 // and once we get one we map it through our History driver

--- a/src/dialogue/pages/home/__test__/home.spec.js
+++ b/src/dialogue/pages/home/__test__/home.spec.js
@@ -8,7 +8,7 @@ import intent             from '../home-intent'
 import model              from '../home-model'
 import view               from '../home-view'
 import mockClickEvent     from './mockClickEvent'
-import createRenderTarget from '../../../../__test__/helper/createRenderTarget'
+import createRenderTarget from '__test_helper__/createRenderTarget'
 
 //const userEvents = mockDOMSource({
 //  '.foo': {

--- a/src/dialogue/pages/page1/__test__/page1.spec.js
+++ b/src/dialogue/pages/page1/__test__/page1.spec.js
@@ -4,7 +4,7 @@ import Cycle                from '@cycle/core'
 import {div, makeDOMDriver} from '@cycle/dom'
 import {makeHistoryDriver}  from '@cycle/history';
 import page1                from '../page1-index'
-import createRenderTarget   from '../../../../__test__/helper/createRenderTarget'
+import createRenderTarget   from '__test_helper__/createRenderTarget'
 
 
 test('PAGE 1 TESTS #', function (t) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,8 @@ module.exports = {
     modulesDirectories: ['src', 'node_modules'],
     alias: {
       'pages': path.join(__dirname, '/src/dialogue/pages/'),
-      'utils': path.join(__dirname, '/src/dialogue/utils/')
+      'utils': path.join(__dirname, '/src/dialogue/utils/'),
+      '__test_helper__': path.join(__dirname, '/src/__test__/helper/')
     }
   },
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,10 @@ module.exports = {
 
   resolve: {
     extensions: ['', '.js', '.jsx'],
-    modulesDirectories: ['src', 'node_modules']
+    modulesDirectories: ['src', 'node_modules'],
+    alias: {
+      'pages': path.join(__dirname, '/src/dialogue/pages/')
+    }
   },
 
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,8 @@ module.exports = {
     extensions: ['', '.js', '.jsx'],
     modulesDirectories: ['src', 'node_modules'],
     alias: {
-      'pages': path.join(__dirname, '/src/dialogue/pages/')
+      'pages': path.join(__dirname, '/src/dialogue/pages/'),
+      'utils': path.join(__dirname, '/src/dialogue/utils/')
     }
   },
 


### PR DESCRIPTION
Adding webpack aliases so it resolves paths and we don't need to use `../../` on common paths like **pages**, **utils** and **__test__/helper**